### PR TITLE
fix bug when exiting past lecture

### DIFF
--- a/src/containers/Lecture/Lecture.js
+++ b/src/containers/Lecture/Lecture.js
@@ -211,7 +211,7 @@ class Lecture extends Component{
 	}
 	
 	componentWillUnmount(){
-		if (this.state.isLoading == false && socket!== undefined){
+		if (this.state.isLoading == false && socket !== undefined && socket !== null){
 			console.log(socket)
 			socket.emit("leave_lecture",{lecture_id: this.state.selected_lecture.id})
 		}


### PR DESCRIPTION
when a student never establishes socket (i.e. never go into a live lecture), the socket value will still be still in the default value, null. So when the student goes to the past lecture, the socket is still null. To prevent the socket.emit(), we need to include the mentioned edge case.

if we don't take into account this edge case, react will give an error "Cannot read property 'emit' of null"